### PR TITLE
Attach(): report errors on failure

### DIFF
--- a/losetup.go
+++ b/losetup.go
@@ -94,9 +94,10 @@ func Attach(backingFile string, offset uint64, ro bool) (Device, error) {
 			unix.Syscall(unix.SYS_IOCTL, loopFile.Fd(), ClrFd, 0)
 			return dev, fmt.Errorf("could not set info")
 		}
+		return dev, nil
+	} else {
+		return dev, errno
 	}
-
-	return dev, nil
 }
 
 // Detach removes the file backing the device.


### PR DESCRIPTION
Previously, Attach() happily returned a nil error when something bad
happened (like -EBUSY). Let's report this error.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>