### PR TITLE
Add direct construction

### DIFF
--- a/device.go
+++ b/device.go
@@ -14,6 +14,12 @@ type Device struct {
 	flags int
 }
 
+// New creates a reference to a specific loop device, if you know which one you
+// want to reference.
+func New(number uint64, flags int) Device {
+	return Device{number, flags}
+}
+
 // open returns a file handle to /dev/loop# and returns an error if it cannot
 // be opened.
 func (device Device) open() (*os.File, error) {

--- a/info.go
+++ b/info.go
@@ -42,7 +42,7 @@ func getInfo(fd uintptr) (Info, error) {
 	if errno == unix.ENXIO {
 		return Info{}, fmt.Errorf("device not backed by a file")
 	} else if errno != 0 {
-		return Info{}, fmt.Errorf("could not get info about %v (err: %d): %v", errno, errno)
+		return Info{}, fmt.Errorf("could not get info about %v (err: %d): %v", fd, errno, errno)
 	}
 
 	return retInfo, nil
@@ -64,7 +64,7 @@ func setInfo(fd uintptr, info Info) error {
 	if errno == unix.ENXIO {
 		return fmt.Errorf("device not backed by a file")
 	} else if errno != 0 {
-		return fmt.Errorf("could not get info about %v (err: %d): %v", errno, errno)
+		return fmt.Errorf("could not get info about %v (err: %d): %v", fd, errno, errno)
 	}
 
 	return nil


### PR DESCRIPTION
We're doing grotty stuff with devicemapper directly, and know what loop device we want. Let's expose this API directly, vs. only being available when attaching or similar.