### PR TITLE
Add support for alternate block size

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -29,15 +29,17 @@ const (
 	MaxCrypt       = 20
 
 	// ioctl commands
-	SetFd       = 0x4C00
-	ClrFd       = 0x4C01
-	SetStatus   = 0x4C02
-	GetStatus   = 0x4C03
-	SetStatus64 = 0x4C04
-	GetStatus64 = 0x4C05
-	ChangeFd    = 0x4C06
-	SetCapacity = 0x4C07
-	SetDirectIO = 0x4C08
+	SetFd         = 0x4C00
+	ClrFd         = 0x4C01
+	SetStatus     = 0x4C02
+	GetStatus     = 0x4C03
+	SetStatus64   = 0x4C04
+	GetStatus64   = 0x4C05
+	ChangeFd      = 0x4C06
+	SetCapacity   = 0x4C07
+	SetDirectIO   = 0x4C08
+	SetBlockSize  = 0x4C09
+	LoopConfigure = 0x4C0A
 
 	CtlAdd     = 0x4C80
 	CtlRemove  = 0x4C81

--- a/device.go
+++ b/device.go
@@ -3,6 +3,7 @@ package losetup
 import (
 	"fmt"
 	"os"
+	"golang.org/x/sys/unix"
 )
 
 // Device represents a loop device /dev/loop#
@@ -29,4 +30,22 @@ func (device Device) open() (*os.File, error) {
 // Path returns the path to the loopback device
 func (device Device) Path() string {
 	return fmt.Sprintf(DeviceFormatString, device.number)
+}
+
+// Change the default block size (512 bytes) for a loop device,
+// returns an error if the blocksize can't be set.
+func (device Device) SetBlockSize(blockSize uint32) error {
+	f, err := device.open()
+	if err != nil {
+		return fmt.Errorf("couldn't open loop device: %v", err)
+	}
+
+	defer f.Close()
+
+	_, _, err = unix.Syscall(unix.SYS_IOCTL, f.Fd(), SetBlockSize, uintptr(blockSize))
+	if err != 0 {
+		return fmt.Errorf("Failed to set block size: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Since newer storage such as UFS or NVMe use a non-default 4096 bytes block size,
we can no longer create or open an image for these devices.

Add a method to change the loop device block size.